### PR TITLE
Adds parameterisation to helper r scripts [create_report]

### DIFF
--- a/bin/DTable.R
+++ b/bin/DTable.R
@@ -61,7 +61,16 @@ DTable <- function(df = df,
     # Change fontsize of cell values
     formatStyle(columns    = seq_along(colnames(df)), 
                 fontSize   = "85%",
-                fontFamily = "sans-serif")  -> fancyDatatable
+                fontFamily = "sans-serif")   %>%
+
+    formatSignif(
+      columns = unlist(lapply(df, is.numeric),
+      digits = 2,
+      interval = 3,
+      mark = ",",
+      dec.mark = getOption("OutDec")
+      )                 -> fancyDatatable
+
   
   return(fancyDatatable)  
 }

--- a/bin/DTable.R
+++ b/bin/DTable.R
@@ -64,12 +64,11 @@ DTable <- function(df = df,
                 fontFamily = "sans-serif")   %>%
 
     formatSignif(
-      columns = unlist(lapply(df, is.numeric),
+      columns = unlist(lapply(df, is.numeric)),
       digits = 2,
       interval = 3,
       mark = ",",
-      dec.mark = getOption("OutDec")
-      )                 -> fancyDatatable
+      dec.mark = getOption("OutDec"))                 -> fancyDatatable
 
   
   return(fancyDatatable)  

--- a/bin/concat_chroms.R
+++ b/bin/concat_chroms.R
@@ -1,9 +1,112 @@
 #!/usr/bin/env Rscript
 
-library(plyr)
-library(data.table)
+############################## ARGUMENTS SECTION #############################
+## Collect arguments
+args <- commandArgs(TRUE)
 
-paths <- list.files(".", pattern = "txt", full.names = TRUE)
+## Default setting when no all arguments passed or help needed
+if("--help" %in% args | "help" %in% args | (length(args) == 0) | (length(args) == 1) ) {
+  cat("
+      The helper R Script concat_chroms.R
+
+      Mandatory arguments:
+        --output_tag=value         - A string in single quotes used as the identifier of the analysis
+                                     in the output files name. Don't use whitespaces or irregular characters.
+                                     The name will be converted to snakecase (eg. snake_case)
+
+         --help                    - you are reading it
+
+      Optional arguments:
+        --filename_pattern=value  - The pattern of the SAIGE generated individual results files,
+                                    used in list.files() for finding the files to concatenate.
+                                    Default: '.SAIGE.gwas.txt'
+
+        --saige_output_name=path   - The desired output identifier of the concatenated SAIGE output file with all the individual regions.
+                                     Default: 'saige_results'
+                                     NOTE:
+                                     The name will be converted to snakecase (eg. snake_case)
+                                     The final file name will be created by combining the output_tag value and this optional argument.
+                                     eg.
+                                     output_tag = 'covid1'
+                                     saige_output_name = 'saige_results',
+                                     then the final file name will be:
+                                     'saige_results_covid1.csv'
+
+        --top_n_sites=int          - The top N sites from the SAIGE results to be displayed in the report.
+                                     The ranking is by ascending p-value.
+                                     Default: 200
+                                     NOTE:
+                                     The maximum limit for this option is set by the parameter max_top_n_sites
+
+        --max_top_n_sites=int      - The maximum allowed top N sites from the SAIGE results to be displayed in the report.
+                                     Default: 1000
+                                     NOTE:
+                                     This is the upper bound for the values that top_n_sites can take.
+
+     Usage:
+
+          The typical command for running the script is as follows:
+
+          ./concat_chroms.R --output_tag='covid_1'
+
+     Output:
+
+      Returns one .csv file {saige_output_name}_{output_tag}.csv, with the concatenated results
+      across all tested genomic regions in the GWAS.
+
+      See ./concat_chroms.R --help for more details.
+
+      \n")
+
+  q(save="no")
+}
+
+## Parse arguments (we expect the form --arg=value)
+parseArgs    <- function(x) strsplit(sub("^--", "", x), "=")
+
+argsL        <- as.list(as.character(as.data.frame(do.call("rbind", parseArgs(args)))$V2))
+names(argsL) <- as.data.frame(do.call("rbind", parseArgs(args)))$V1
+args         <- argsL
+rm(argsL)
+
+## Give some value to optional arguments if not provided
+if(is.null(args$filename_pattern)) {args$filename_pattern = ".SAIGE.gwas.txt"} else {args$filename_pattern=as.character(args$filename_pattern)}
+if(is.null(args$saige_output_name)) {args$saige_output_name = "saige_results"} else {args$saige_output_name=as.character(args$saige_output_name)}
+if(is.null(args$top_n_sites)) {args$top_n_sites = 200} else {args$top_n_sites=as.numeric(args$top_n_sites)}
+if(is.null(args$max_top_n_sites)) {args$max_top_n_sites = 1000} else {args$max_top_n_sites=as.numeric(args$max_top_n_sites)}
+
+############################## LIBRARIES SECTION #############################
+
+suppressWarnings(suppressMessages(library(plyr)))
+suppressWarnings(suppressMessages(library(data.table)))
+suppressWarnings(suppressMessages(library(snakecase)))
+
+# ######################### VARIABLES REASSIGNMENT SECTION ###############################
+
+# Facilitates testing and protects from wh-spaces, irregular chars
+
+# required
+output_tag         <- snakecase::to_snake_case(as.character(args$output_tag))
+
+# optional
+filename_pattern   <- as.character(args$filename_pattern)
+saige_output_name  <- snakecase::to_snake_case(as.character(args$saige_output_name))
+max_top_n_sites    <- as.numeric(args$max_top_n_sites)
+top_n_sites        <- ifelse(as.numeric(args$top_n_sites) > max_top_n_sites, max_top_n_sites, as.numeric(args$top_n_sites))
+
+cat("\n")
+cat("ARGUMENTS SUMMARY")
+cat("\n")
+cat("output_tag         : ", output_tag         ,"\n",sep="")
+cat("filename_pattern   : ", filename_pattern   ,"\n",sep="")
+cat("saige_output_name  : ", saige_output_name  ,"\n",sep="")
+cat("top_n_sites        : ", top_n_sites        ,"\n",sep="")
+
+# ############################### SCRIPT SECTION ###############################
+
+paths <- list.files(".", pattern = filename_pattern, full.names = TRUE)
 list_of_dfs <- lapply(paths,data.table::fread)
-analysis <- plyr::rbind.fill(list_of_dfs)
-data.table::fwrite(analysis, "analysis.csv", sep = ",")
+saige_results <- plyr::rbind.fill(list_of_dfs)
+saige_results_sorted_topN <- saige_results[order(saige_results[['p.value']]),][1:top_n_sites,]
+data.table::fwrite(saige_results, paste0(saige_output_name, "_", output_tag, ".csv"), sep = ",")
+data.table::fwrite(saige_results_sorted_topN, "saige_results_top_n.csv", sep = ",")

--- a/bin/gwas_report.Rmd
+++ b/bin/gwas_report.Rmd
@@ -71,6 +71,11 @@ htmltools::tags$figcaption( style = 'caption-side: bottom; text-align: center; f
 ```{r}
 table   <- as.data.frame(data.table::fread(params$saige_results))
 colnames(table) <- snakecase::to_snake_case(colnames(table))
+reordered_columns <- c("CHR", "POS", "SNPID",  "p.value", "imputationInfo", "N", "BETA", "SE", "Tstat",
+"p.value.NA", "Is.SPA.converge", "varT", "varTstar", "AF.Cases",  "Allele1", "Allele2", "AC_Allele2",
+"AF_Allele2", "AF.Controls", "N.Cases", "N.Controls", "homN_Allele2_cases",
+"hetN_Allele2_cases", "homN_Allele2_ctrls", "hetN_Allele2_ctrls")
+table <- table[, reordered_columns]
 DTable(table)
 ```
 

--- a/bin/gwas_report.Rmd
+++ b/bin/gwas_report.Rmd
@@ -13,6 +13,7 @@ params:
   manhattan:  "covid_1_manhattan.png"
   qqplot:  "covid_1_qqplot_ci.png"
   gwascat: "gwascat_subset.csv"
+  saige_results: "saige_results_top_n.csv"
 title: "`r paste0('Genomics England GWAS Report' , '') `"
 author: ""
 date: ""
@@ -63,6 +64,14 @@ knitr::include_graphics(params$qqplot, )
 htmltools::tags$figcaption( style = 'caption-side: bottom; text-align: center; font-size: 85%%; color: #71879d',
                             htmltools::em(figure_number), 
                             htmltools::em(figure_caption))
+```
+
+# SAIGE output
+
+```{r}
+table   <- as.data.frame(data.table::fread(params$saige_results))
+colnames(table) <- snakecase::to_snake_case(colnames(table))
+DTable(table)
 ```
 
 # GWAS catalogue information

--- a/bin/gwas_report.Rmd
+++ b/bin/gwas_report.Rmd
@@ -71,10 +71,11 @@ htmltools::tags$figcaption( style = 'caption-side: bottom; text-align: center; f
 ```{r}
 table   <- as.data.frame(data.table::fread(params$saige_results))
 colnames(table) <- snakecase::to_snake_case(colnames(table))
-reordered_columns <- c("CHR", "POS", "SNPID",  "p.value", "imputationInfo", "N", "BETA", "SE", "Tstat",
-"p.value.NA", "Is.SPA.converge", "varT", "varTstar", "AF.Cases",  "Allele1", "Allele2", "AC_Allele2",
-"AF_Allele2", "AF.Controls", "N.Cases", "N.Controls", "homN_Allele2_cases",
-"hetN_Allele2_cases", "homN_Allele2_ctrls", "hetN_Allele2_ctrls")
+reordered_columns <-
+c("chr", "pos", "snpid", "p_value", "imputation_info", "n", "beta", "se", "tstat",
+ "p_value_na", "is_spa_converge", "var_t", "var_tstar", "allele_1", "allele_2", "ac_allele_2",
+"af_allele_2","af_cases", "af_controls", "n_cases", "n_controls", "hom_n_allele_2_cases",
+"het_n_allele_2_cases", "hom_n_allele_2_ctrls", "het_n_allele_2_ctrls")
 table <- table[, reordered_columns]
 DTable(table)
 ```

--- a/bin/subset_gwascat.R
+++ b/bin/subset_gwascat.R
@@ -1,9 +1,74 @@
 #!/usr/bin/env Rscript
 
-library(data.table)
+############################## ARGUMENTS SECTION #############################
+## Collect arguments
+args <- commandArgs(TRUE)
 
-a <- as.data.frame(data.table::fread("analysis.csv"))
+## Default setting when no all arguments passed or help needed
+if("--help" %in% args | "help" %in% args | (length(args) == 0) | (length(args) == 1) ) {
+  cat("
+      The helper R Script subset_gwascat.R
+
+      Mandatory arguments:
+          --saige_output=path       - The path to the SAIGE output file.
+                                      NOTE:
+                                      If you have performed the analysis per chromosome,
+                                      concatenate outputs across all chromosomes first.
+
+         --gwas_cat=path            - The path to the NHGRI-EBI Catalog of published genome-wide association studies
+                                      provided as a .csv file.
+                                      NOTE:
+                                      This can be retrieved using the bioconductor R package 'gwascat':
+                                      gwascat <- as.data.frame(gwascat::makeCurrentGwascat())
+                                      data.table::fwrite(gwascat, 'gwascat.csv', sep = ',')
+
+         --help                     - you are reading it
+
+     Usage:
+
+          The typical command for running the script is as follows:
+
+          ./subset_gwascat.R --saige_output='saige_results.csv' --gwas_cat='gwascat.csv'
+
+     Output:
+
+      Returns the GWAS Catalogue information as a .csv file of the top N ranked sites based on the SAIGE p.values column.
+
+      \n")
+
+  q(save="no")
+}
+
+## Parse arguments (we expect the form --arg=value)
+parseArgs    <- function(x) strsplit(sub("^--", "", x), "=")
+
+argsL        <- as.list(as.character(as.data.frame(do.call("rbind", parseArgs(args)))$V2))
+names(argsL) <- as.data.frame(do.call("rbind", parseArgs(args)))$V1
+args         <- argsL
+rm(argsL)
+
+############################## LIBRARIES SECTION #############################
+
+suppressWarnings(suppressMessages(library(data.table)))
+
+# ######################### VARIABLES REASSIGNMENT SECTION ###############################
+
+# Facilitates testing and protects from wh-spaces, irregular chars
+
+# required
+saige_output     <- as.character(args$saige_output)
+gwas_cat         <- as.character(args$gwas_cat)
+
+cat("\n")
+cat("ARGUMENTS SUMMARY")
+cat("\n")
+cat("saige_output     : ", saige_output     ,"\n",sep="")
+cat("gwas_cat         : ", gwas_cat         ,"\n",sep="")
+
+# ############################### SCRIPT SECTION ###############################
+
+a <- as.data.frame(data.table::fread(saige_output))
 to_keep <- a[["SNPID"]]
-b <- as.data.frame(data.table::fread("gwascat.csv"))
+b <- as.data.frame(data.table::fread(gwas_cat))
 c <- b[ b$SNPS %in% to_keep, ]
 data.table::fwrite(c, file = "gwascat_subset.csv", sep = ",")

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,6 +12,9 @@ params {
   outdir = 'results'
   gwas_cat = 's3://lifebit-featured-datasets/projects/gel/gel-gwas/gwascat.csv'
   output_tag = 'covid_1'
+  top_n_sites = 200
+  max_top_n_sites = 1000
+  saige_filename_pattern = '.SAIGE.gwas.txt'
 }
 
 process {
@@ -24,7 +27,6 @@ process {
     container = 'wzhou88/saige:0.39'
   }
   withName: create_report {
-     cpus = 10
-     memory = 20.GB
+     cpus = 2
   }
 }


### PR DESCRIPTION
This PR completes the parameterisation of all the currently created and used R scripts.

Here is a list of the scripts changed in this PR with a short description of the files functionality:

- [ ] `bin/concat_chroms.R`: R script that can be run from the command line. Concatenates SAIGE output files that have been generated by running SAIGE in separate chromosomal regions and creates the unified final csv file that contains all the examined sites in the GWAS performed
- [ ] `bin/DTable.R`:  Script with a utility function, to use the `DT` R package and render an interactive table in the rmarkdown report.
- [ ] `bin/subset_gwascat.R`: 
- [ ] `bin/gwas_report.Rmd `: The rmarkdown file that will generate the GWAS html report. Here updated to display the SAIGE output as an interactive DT data table, in addition to the previously added GWAS catalogue.

Also updated:

- [ ] `main.nf`, to include docs and code changes in scripts and add parameterised scripts
- [ ] `nextflow.config`, to include new exposed parameters from the parameterised R scripts



Here's an example CloudOS link with the report (check temporarily named `MultiQC` slot):
https://cloudos.lifebit.ai/public/jobs/5f57a8b617041401122ad179
